### PR TITLE
Clarify undo restores data only, not filter or view state

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -196,7 +196,7 @@ Step 3. The user executes `add n/David …​` to add a new opportunity contact.
 
 </box>
 
-Step 4. The user now decides that adding the opportunity contact was a mistake, and decides to undo that action by executing the `undo` command. The `undo` command will call `Model#undoAddressBook()`, which will shift the `currentStatePointer` once to the left, pointing it to the previous tracker state, and restores the tracker data to that state.
+Step 4. The user now decides that adding the opportunity contact was a mistake, and decides to undo that action by executing the `undo` command. The `undo` command will call `Model#undoAddressBook()`, which will shift the `currentStatePointer` once to the left, pointing it to the previous tracker state, and restore the tracker data to that state.
 
 <puml src="diagrams/UndoState3.puml" alt="UndoState3" />
 
@@ -618,7 +618,7 @@ Preconditions: At least one opportunity contact exists in the archived list.
 
       Use case ends.
 
-**Note:** `undo` restores the underlying tracker data only. It does not restore the previously displayed filtered list or the current Main/Archive view.
+**Note:** `undo` restores the underlying tracker data only. It does not modify the current UI state, including the currently displayed filtered list and the selected Main/Archive view.
 
 **Use case: UC10 — Clear opportunity contact**
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -196,7 +196,7 @@ Step 3. The user executes `add n/David …​` to add a new opportunity contact.
 
 </box>
 
-Step 4. The user now decides that adding the opportunity contact was a mistake, and decides to undo that action by executing the `undo` command. The `undo` command will call `Model#undoAddressBook()`, which will shift the `currentStatePointer` once to the left, pointing it to the previous tracker state, and restores the tracker to that state.
+Step 4. The user now decides that adding the opportunity contact was a mistake, and decides to undo that action by executing the `undo` command. The `undo` command will call `Model#undoAddressBook()`, which will shift the `currentStatePointer` once to the left, pointing it to the previous tracker state, and restores the tracker data to that state.
 
 <puml src="diagrams/UndoState3.puml" alt="UndoState3" />
 
@@ -606,7 +606,7 @@ Preconditions: At least one opportunity contact exists in the archived list.
 **MSS**
 
 1.  User requests to undo the previous mutating command.
-2.  System restores the tracker to its previous state.
+2.  System restores the tracker data to its previous state.
 3.  System displays a success message.
 
     Use case ends.
@@ -617,6 +617,8 @@ Preconditions: At least one opportunity contact exists in the archived list.
     * 1a1. System shows an error message indicating there are no more commands to undo.
 
       Use case ends.
+
+**Note:** `undo` restores the underlying tracker data only. It does not restore the previously displayed filtered list or the current Main/Archive view.
 
 **Use case: UC10 — Clear opportunity contact**
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -268,6 +268,12 @@ Format: `undo`
 * The `undo` command only works if there is a previous state to restore. If you have just launched the app or have already undone all recent commands, executing `undo` will fail with a "No more commands to undo!" error.
 * Read-only commands (like `list` or `find`) do not modify the tracker's state and cannot be undone.
 
+<box type="info" seamless>
+
+**Note:** `undo` restores the previous opportunity data, but it does not restore the previously displayed list, active `find` results, or the current **Main/Archive** view. If the list looks empty or incomplete after `undo`, run `list`, `list archive`, or the relevant `find` command again.
+
+</box>
+
 ![undo](images/release_v1.5/Undo.png)
 
 ### Clearing all entries : `clear`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -270,7 +270,7 @@ Format: `undo`
 
 <box type="info" seamless>
 
-**Note:** `undo` restores the previous opportunity data, but it does not restore the previously displayed list, active `find` results, or the current **Main/Archive** view. If the list looks empty or incomplete after `undo`, run `list`, `list archive`, or the relevant `find` command again.
+**Note:** `undo` restores the previous opportunity data only. It keeps the current list filter (including any active `find`) and the current **Main/Archive** tab unchanged, and applies that current view to the restored data. If the list looks empty or incomplete after `undo`, run `list`, `list archive`, or the relevant `find` command to switch to the view you expect.
 
 </box>
 


### PR DESCRIPTION
Fixes #384. Fixes #403.